### PR TITLE
Switch id request from get to put

### DIFF
--- a/lib/omniauth/strategies/salesforce.rb
+++ b/lib/omniauth/strategies/salesforce.rb
@@ -68,7 +68,7 @@ module OmniAuth
       def raw_info
         access_token.options[:mode] = :query
         access_token.options[:param_name] = :oauth_token
-        @raw_info ||= access_token.post(access_token['id']).parsed
+        @raw_info ||= access_token.get(access_token['id']).parsed
       end
 
       extra do


### PR DESCRIPTION
When the info request is a post, I consistently get this error:
(salesforce) Authentication failure! invalid_credentials: OAuth2::Error, Missing_OAuth_Token

This is despite the post having an oauth token parameter:

post https://login.salesforce.com/id/obfuscated/obfuscated?oauth_token=obfuscated

It seems that this request doesn't have to be a post in the first place, and changing it to a get consistently makes the request succeed. I confess to not having tracked down why, _exactly_, the change works.

This is using faraday (0.9.0). Perhaps it is a faraday compatibility issue with how the post request is constructed. This working sample:
https://github.com/takahiro-yonei/OmniAuth-Salesforce-Sample
uses Faraday 0.7.6.

e.g., it could be an error in how the Oauth2 gem is constructing its post request, by having it be a param rather than in the request body.

Sorry to not be more helpful on that part -- but can we at least focus on why it's a post and not a get, and whether changing it to a get is acceptable? Because that will avoid this problem entirely.
