### PR TITLE
Replace the query access token method with headers

### DIFF
--- a/lib/omniauth/strategies/salesforce.rb
+++ b/lib/omniauth/strategies/salesforce.rb
@@ -66,8 +66,7 @@ module OmniAuth
       end
 
       def raw_info
-        access_token.options[:mode] = :query
-        access_token.options[:param_name] = :oauth_token
+        access_token.options[:mode] = :header
         @raw_info ||= access_token.post(access_token['id']).parsed
       end
 


### PR DESCRIPTION
Query tokens are not a reliable way to communicate the token with SFDC. Randomly, SFDC will say no oauth token even though it is sent across the wire.
