### PR TITLE
use header based authorization when getting user info

### DIFF
--- a/lib/omniauth/strategies/salesforce.rb
+++ b/lib/omniauth/strategies/salesforce.rb
@@ -66,8 +66,7 @@ module OmniAuth
       end
 
       def raw_info
-        access_token.options[:mode] = :query
-        access_token.options[:param_name] = :oauth_token
+        access_token.options[:mode] = :header
         @raw_info ||= access_token.post(access_token['id']).parsed
       end
 


### PR DESCRIPTION
We experienced the issue that sometimes after getting access_token, the second request failed. As we found on Stack Overflow (http://stackoverflow.com/questions/20486048/salesforce-oauth2-missing-oauth-token
) and according to Salesforce documentation the header based authentication should be used.
