### PR TITLE
Allow dynamic redirect uri from provider configuration

### DIFF
--- a/lib/omniauth/strategies/salesforce.rb
+++ b/lib/omniauth/strategies/salesforce.rb
@@ -18,7 +18,8 @@ module OmniAuth
         :display,
         :immediate,
         :state,
-        :prompt
+        :prompt,
+        :redirect_uri
       ]
 
       def request_phase


### PR DESCRIPTION
By adding this to the strategy you can pass the redirect uri directly in the configuration of the provider.

For example, with devise in devise.rb:

    Devise.setup do |config|

      config.omniauth :salesforce, 'key', 'secret', {redirect_uri: 'http://localhost:3000/users/auth/salesforce/callback'}

    end