### PR TITLE
add login_hint to authorize_options

### DIFF
--- a/lib/omniauth/strategies/salesforce.rb
+++ b/lib/omniauth/strategies/salesforce.rb
@@ -19,7 +19,8 @@ module OmniAuth
         :immediate,
         :state,
         :prompt,
-        :redirect_uri
+        :redirect_uri,
+        :login_hint
       ]
 
       def request_phase


### PR DESCRIPTION
Salesforce supports the login_hint option to pre-fill the email address when known. 

http://docs.releasenotes.salesforce.com/en-us/spring14/release-notes/rn_forcecom_security_user_login_hint.htm

You don't seem to be testing the authorize_options at all so I didn't add any specs.