### PR TITLE
update omniauth-oauth2, add rubocop and minor cleanup

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,10 @@
 source 'https://rubygems.org'
 
-# Specify your gem's dependencies in omniauth-salesforce.gemspec
 gemspec
+
+group :development do
+  gem 'rubocop', '~> 0.52.1', require: false
+end
 
 group :development, :test do
   gem 'guard'

--- a/lib/omniauth-salesforce.rb
+++ b/lib/omniauth-salesforce.rb
@@ -1,2 +1,2 @@
-require "omniauth-salesforce/version"
+require 'omniauth-salesforce/version'
 require 'omniauth/strategies/salesforce'

--- a/lib/omniauth-salesforce/version.rb
+++ b/lib/omniauth-salesforce/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module Salesforce
-    VERSION = "1.0.5"
+    VERSION = '1.1.0'
   end
 end

--- a/omniauth-salesforce.gemspec
+++ b/omniauth-salesforce.gemspec
@@ -1,25 +1,25 @@
-# -*- encoding: utf-8 -*-
 require File.expand_path('../lib/omniauth-salesforce/version', __FILE__)
 
 Gem::Specification.new do |gem|
-  gem.authors       = ["Richard Vanhook"]
-  gem.email         = ["rvanhook@salesforce.com"]
-  gem.description   = %q{OmniAuth strategy for salesforce.com.}
-  gem.summary       = %q{OmniAuth strategy for salesforce.com.}
-  gem.homepage      = "https://github.com/realdoug/omniauth-salesforce"
+  gem.authors       = ['Richard Vanhook']
+  gem.email         = ['rvanhook@salesforce.com']
+  gem.description   = 'OmniAuth strategy for salesforce.com.'
+  gem.summary       = 'OmniAuth strategy for salesforce.com.'
+  gem.homepage      = 'https://github.com/realdoug/omniauth-salesforce'
 
-  gem.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
-  gem.files         = `git ls-files`.split("\n")
-  gem.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
-  gem.name          = "omniauth-salesforce"
-  gem.require_paths = ["lib"]
+  gem.executables   = `git ls-files -- bin/*`.split('\n').map { |f| File.basename(f) }
+  gem.files         = `git ls-files`.split('\n')
+  gem.test_files    = `git ls-files -- {test,spec,features}/*`.split('\n')
+  gem.name          = 'omniauth-salesforce'
+  gem.require_paths = ['lib']
   gem.version       = OmniAuth::Salesforce::VERSION
-  gem.license       = "MIT"
+  gem.license       = 'MIT'
 
   gem.add_dependency 'omniauth', '~> 1.0'
-  gem.add_dependency 'omniauth-oauth2', '~> 1.0'
-  gem.add_development_dependency 'rspec', '~> 2.7'
+  gem.add_dependency 'omniauth-oauth2', '>= 1.5.0'
+  gem.required_ruby_version = '>= 2.1.0'
   gem.add_development_dependency 'rack-test'
+  gem.add_development_dependency 'rspec', '~> 2.7'
   gem.add_development_dependency 'simplecov'
   gem.add_development_dependency 'webmock'
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
-$:.unshift File.expand_path('..', __FILE__)
-$:.unshift File.expand_path('../../lib', __FILE__)
+$LOAD_PATH.unshift File.expand_path('..', __FILE__)
+$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+
 require 'simplecov'
 SimpleCov.start
 require 'rspec'
@@ -11,6 +12,5 @@ require 'omniauth-salesforce'
 RSpec.configure do |config|
   config.include WebMock::API
   config.include Rack::Test::Methods
-  config.extend  OmniAuth::Test::StrategyMacros, :type => :strategy
+  config.extend  OmniAuth::Test::StrategyMacros, type: :strategy
 end
-


### PR DESCRIPTION
### changes:
- update `omniauth-oauth2`
  * omniauth: which bump hashie and rack gem
  * oauth2: relax faraday gem, possible for higher version
- fix 2 warnings:
  * WARN -- : You are setting a key that conflicts with a built-in method OmniAuth::AuthHash::InfoHash#name defined at `../gems/omniauth-1.3.1/lib/omniauth/auth_hash.rb:34.` This can cause unexpected behavior when accessing the key as a property. You can still access the key via the #[] method.

  * DEPRECATION WARNING: alias_method_chain is deprecated. Please, use Module#prepend instead. From module, you can access the original method using super.
- rubocop for better code quality in future