### PR TITLE
Fix dynamic change of client_options.site

### DIFF
--- a/lib/omniauth/strategies/salesforce.rb
+++ b/lib/omniauth/strategies/salesforce.rb
@@ -34,6 +34,11 @@ module OmniAuth
         super
       end
 
+      def callback_phase
+        options.update(@env["omniauth.params"])
+        super
+      end      
+
       def auth_hash
         signed_value = access_token.params['id'] + access_token.params['issued_at']
         raw_expected_signature = OpenSSL::HMAC.digest('sha256', options.client_secret.to_s, signed_value)


### PR DESCRIPTION
The client_options.site updated for the `request_phase` using request params is also updated for the `callback_phase`

Perhaps I'm wrong, but as it is possible to dynamically update the target client_options.site (eg : https://login.salesforce.com or https://test.salesforce.com) during the `request_phase` it seems logical to use this same site during the `callback_phase`, isn't ?

Best regards,