### PR TITLE
Update omniauth dependency version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,21 @@
+name: Test
+
+on: push
+
+env:
+  bundle-cache: vendor/bundle
+  BUNDLE_JOBS: 3
+  BUNDLE_RETRY: 3
+
+jobs:
+  backend-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.6.6
+          bundler-cache: true
+      - name: Build and test with Rake
+        run: |
+          bundle exec rake

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,6 @@ jobs:
         with:
           ruby-version: 2.6.6
           bundler-cache: true
-      - name: Build and test with Rake
+      - name: Build and test with rspec
         run: |
-          bundle exec rake
+          bundle exec rspec

--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
 --colour
+--format documentation

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [OmniAuth](https://github.com/intridea/omniauth) Strategy for [salesforce.com](salesforce.com).
 
-Note: This is a fork of the [original](https://github.com/richardvanhook/omniauth-salesforce) project and is now the main repository for the omniauth-salesforce gem.
+Note: This is an Accel fork of the fork of the [original](https://github.com/richardvanhook/omniauth-salesforce) project - due to dependencies not being updated.
 
 ## See it in action
 

--- a/lib/omniauth-salesforce/version.rb
+++ b/lib/omniauth-salesforce/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module Salesforce
-    VERSION = '1.1.0'
+    VERSION = '1.1.1'
   end
 end

--- a/omniauth-salesforce.gemspec
+++ b/omniauth-salesforce.gemspec
@@ -15,8 +15,8 @@ Gem::Specification.new do |gem|
   gem.version       = OmniAuth::Salesforce::VERSION
   gem.license       = 'MIT'
 
-  gem.add_dependency 'omniauth', '~> 1.0'
-  gem.add_dependency 'omniauth-oauth2', '>= 1.5.0'
+  gem.add_dependency 'omniauth', '~> 2.0'
+  gem.add_dependency 'omniauth-oauth2', '~> 1.7.1'
   gem.required_ruby_version = '>= 2.1.0'
   gem.add_development_dependency 'rack-test'
   gem.add_development_dependency 'rspec', '~> 2.7'


### PR DESCRIPTION
Resolve issue whereby omniauth gem is restricted to v1.x (as per [issue 31](https://github.com/realdoug/omniauth-salesforce/issues/31))