### PR TITLE
Migrate to GHA for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on: push
+
+jobs:
+  tests:
+      strategy:
+        fail-fast: false
+        matrix:
+          os: [ubuntu-18.04, ubuntu-20.04, ubuntu-22.04]
+          ruby: [ 2.7, 3.0, 3.1, 3.2 ]
+
+      runs-on: ${{ matrix.os }}
+
+      name: ${{ matrix.os }} - ${{ matrix.ruby }}
+
+      steps:
+        - uses: actions/checkout@v2
+        - uses: ruby/setup-ruby@v1
+          with:
+            ruby-version: ${{ matrix.ruby }}
+            bundler-cache: true
+
+        - name: Run specs
+          run: bundle exec rspec


### PR DESCRIPTION
This repo is currently not configured with CI. Let's move it to GHA and test against a few Linux and Ruby versions.